### PR TITLE
fix: fix error when no logs queried

### DIFF
--- a/duo/src/main.rs
+++ b/duo/src/main.rs
@@ -75,7 +75,7 @@ async fn main() -> Result<()> {
 
             let duo_layer = DuoLayer::new(
                 "duo",
-                format!("http://127.0.0.1:{}", grpc_port).parse().unwrap(),
+                format!("grpc://127.0.0.1:{}", grpc_port).parse().unwrap(),
             )
             .await;
             tracing_subscriber::registry()

--- a/duo/src/web/query.rs
+++ b/duo/src/web/query.rs
@@ -53,7 +53,7 @@ impl<'a> TraceQuery<'a> {
                 continue;
             }
             if let Some(span_name) = p.operation.as_ref() {
-                if &*span.name != span_name {
+                if &span.name != span_name {
                     continue;
                 }
             }
@@ -102,7 +102,7 @@ impl<'a> TraceQuery<'a> {
                 col("trace_id").in_list(trace_ids.into_iter().map(|id| lit(*id)).collect(), false),
             )
             .await
-            .unwrap()
+            .unwrap_or_default()
             .into_iter();
         debug!("span logs from parquet: {}", logs.len());
         trace_logs.extend(logs);
@@ -156,7 +156,7 @@ impl<'a> TraceQuery<'a> {
             let logs = pq
                 .query_log(col("trace_id").eq(lit(trace_id)))
                 .await
-                .unwrap();
+                .unwrap_or_default();
             debug!("trace `{trace_id}` logs from parquet: {}", logs.len());
             trace_logs.extend(logs);
             Some(TraceExt {


### PR DESCRIPTION
Tokio's thread got panicked, when no logs queried from local file.

```
thread 'tokio-runtime-worker' panicked at 'called `Result::unwrap()` on an `Err` value: Schema error: No field named trace_id. Valid fields are "?table?".level, "?table?".message, "?table?".process_id, "?table?".time.

Caused by:
    No field named trace_id. Valid fields are "?table?".level, "?table?".message, "?table?".process_id, "?table?".time.', duo/src/web/query.rs:105:14
```

use unwrap_or_default to avoid panic.