### PR TITLE
opt: use map drain api to avoid string copy

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ gRPC server listening on http://127.0.0.1:6000
 Web server listening on http://127.0.0.1:3000
 ```
 
-Open https://127.0.0.1:3000 at your local browser to wait application report data.
+Open http://127.0.0.1:3000 at your local browser to wait application report data.
 
 ### Application
 

--- a/duo/src/arrow.rs
+++ b/duo/src/arrow.rs
@@ -74,7 +74,7 @@ impl SpanRecordBatchBuilder {
 }
 
 impl LogRecordBatchBuilder {
-    pub fn append_log(&mut self, log: Log) {
+    pub fn append_log(&mut self, mut log: Log) {
         let mut map = Map::new();
         let time = log.as_micros();
         map.insert("process_id".into(), log.process_id.into());
@@ -82,7 +82,8 @@ impl LogRecordBatchBuilder {
         map.insert("trace_id".into(), log.trace_id.into());
         map.insert("level".into(), log.level.as_str().into());
         map.insert("time".into(), time.into());
-        for (key, value) in log.fields {
+
+        for (key, value) in log.fields.drain() {
             map.insert(key, value);
         }
         self.data.push(JsonValue::Object(map));


### PR DESCRIPTION
Use map.drain api to take ownership of String from log.fields instead of copying it which helps to improve performance.