### PR TITLE
Partition intact spans

### DIFF
--- a/duo/src/aggregator.rs
+++ b/duo/src/aggregator.rs
@@ -1,3 +1,5 @@
+use std::mem;
+
 use duo_api as proto;
 
 use crate::Span;
@@ -29,15 +31,10 @@ impl SpanAggregator {
 
     pub fn aggregate(&mut self) -> Vec<Span> {
         // Remove all intact spans.
-        let mut spans = Vec::new();
-        self.spans.retain(|span| {
-            if span.end.is_some() {
-                spans.push(Span::from(span));
-                false
-            } else {
-                true
-            }
-        });
-        spans
+        let (intact_spans, ongoing_spans): (Vec<_>, Vec<_>) = mem::take(&mut self.spans)
+            .into_iter()
+            .partition(|span| span.end.is_some());
+        self.spans = ongoing_spans;
+        intact_spans.into_iter().map(Span::from).collect()
     }
 }

--- a/duo/src/models.rs
+++ b/duo/src/models.rs
@@ -100,9 +100,9 @@ impl Log {
     }
 }
 
-impl From<&proto::Span> for Span {
-    fn from(span: &proto::Span) -> Self {
-        let mut raw_tags = span.tags.clone();
+impl From<proto::Span> for Span {
+    fn from(span: proto::Span) -> Self {
+        let mut raw_tags = span.tags;
         for key in ["busy", "idle"] {
             if let Some(proto::Value {
                 inner: Some(proto::ValueEnum::U64Val(value)),
@@ -121,8 +121,8 @@ impl From<&proto::Span> for Span {
             id: span.id,
             trace_id: span.trace_id,
             parent_id: span.parent_id,
-            process_id: span.process_id.clone(),
-            name: span.name.clone(),
+            process_id: span.process_id,
+            name: span.name,
             start: span
                 .start
                 .and_then(|timestamp| {


### PR DESCRIPTION
Use `Iterator::partition()` to separate intact and ongoing spans to avoid clone.